### PR TITLE
Resolve ambiguity in job id querying

### DIFF
--- a/scripts/submit_csv.sh
+++ b/scripts/submit_csv.sh
@@ -72,7 +72,7 @@ condor_submit -verbose -file ${SUBMIT_FILE}
 
 # create log dir
 if [ $? -eq 0 ] ; then
-  for i in `condor_q | grep ^${USER} | tail -n1 | awk '{print($10)}' | cut -d. -f1` ; do
+  for i in `condor_q | grep ^${USER} | tail -n1 | awk '{print($NF)}' | cut -d. -f1` ; do
     mkdir -p LOG/CONDOR/osg_$i/
   done
 fi


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Immediately after a job is submitted, the job id is in the 9th field. A few moments later, it's in the 10th field. To resolve this ambiguity always pick the last field. 

condor_q | grep ^${USER} | tail -n1 | awk '{print($9)}' | cut -d. -f1
442

condor_q | grep ^${USER} | tail -n1 | awk '{print($9)}' | cut -d. -f1
12174

condor_q | grep ^${USER} | tail -n1 | awk '{print($NF)}' | cut -d. -f1
442

condor_q | grep ^${USER} | tail -n1 | awk '{print($10)}' | cut -d. -f1
442




### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
