### PR TITLE
Change date format in environment script

### DIFF
--- a/scripts/submit_csv.sh
+++ b/scripts/submit_csv.sh
@@ -44,7 +44,7 @@ ARGUMENTS="EVGEN/\$(file) \$(ext) \$(nevents) \$(ichunk)"
 source $(dirname $0)/set_bg_mix_var.sh
 
 # construct environment file
-ENVIRONMENT=environment-$(date --iso-8601=ns).sh
+ENVIRONMENT=environment-$(date '+%Y-%m-%d_%H-%M-%S').sh
 
 # extract certificate name
 X509_USER_PROXY_BASE=$(basename ${X509_USER_PROXY:-})

--- a/scripts/submit_csv.sh
+++ b/scripts/submit_csv.sh
@@ -44,7 +44,7 @@ ARGUMENTS="EVGEN/\$(file) \$(ext) \$(nevents) \$(ichunk)"
 source $(dirname $0)/set_bg_mix_var.sh
 
 # construct environment file
-ENVIRONMENT=environment-$(date '+%Y-%m-%d_%H-%M-%S').sh
+ENVIRONMENT=environment-$(basename ${CSV_FILE} .csv).sh
 
 # extract certificate name
 X509_USER_PROXY_BASE=$(basename ${X509_USER_PROXY:-})


### PR DESCRIPTION
### Briefly, what does this PR introduce?
HTCondor doesn't like ISO format in filenames when it's written down to seconds/nanoseconds because of the presence of consecutive ":"s. We revert to using the minutes format but introduce the dataset name to avoid duplication in quick successive submissions.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
