### PR TITLE
Add MAX_EVENTS_PER_CHUNK env var to cap chunk size

### DIFF
--- a/scripts/csv_to_chunks.sh
+++ b/scripts/csv_to_chunks.sh
@@ -36,6 +36,9 @@ output=$(basename ${FILE} .csv)-$(date --iso-8601=minutes).csv
     ${0} ${TEMPLATE} ${TYPE} ${file} ${TARGET}
   else
     nevents=$(echo "scale=0; n=(3600*$TARGET-$dt0)/$dt1; if (n>$ntotal) print($ntotal) else print(n)" | bc -l)
+    if [ -n "${MAX_EVENTS_PER_CHUNK}" ] && { [ "${nevents}" -le 0 ] || [ "${nevents}" -gt "${MAX_EVENTS_PER_CHUNK}" ]; }; then
+      nevents=${MAX_EVENTS_PER_CHUNK}
+    fi
     nchunks=$(echo "scale=0; n=$ntotal/$nevents+1; if (n==0) print(1) else print(n)" | bc -l)
     nevents=$(echo "scale=0; $ntotal/$nchunks" | bc -l)
     actualt=$(echo "scale=2; ($dt0+$nevents*$dt1)/3600" | bc -l)


### PR DESCRIPTION
When dt0 exceeds the target wall time, the timing formula yields negative/zero nevents, collapsing all events into a single chunk. MAX_EVENTS_PER_CHUNK clamps nevents before nchunks is derived, providing an escape hatch for init-dominated samples.